### PR TITLE
04_leap_year.rbを実装

### DIFF
--- a/04_leap_year.rb
+++ b/04_leap_year.rb
@@ -1,0 +1,15 @@
+YEAR = ARGV[0].to_i
+
+if (YEAR % 4).zero?
+  if (YEAR % 100).zero?
+    if (YEAR % 400).zero?
+      puts "#{YEAR}年はうるう年です"
+    else
+      puts "#{YEAR}年はうるう年ではありません"
+    end
+  else
+    puts "#{YEAR}年はうるう年です"
+  end
+else
+  puts "#{YEAR}年はうるう年ではありません"
+end


### PR DESCRIPTION
## やったこと
[うるう年の判定](https://github.com/rseki-sonix/ruby-code-review/tree/master#4-%E3%81%86%E3%82%8B%E3%81%86%E5%B9%B4%E3%81%AE%E5%88%A4%E5%AE%9A)の実装

## やっていないこと
入力のバリデーション

## 動作確認
```
$ ruby 04_leap_year.rb 1888
1888年はうるう年です
$ ruby 04_leap_year.rb 1900
1900年はうるう年ではありません
$ ruby 04_leap_year.rb 1996
1996年はうるう年です
$ ruby 04_leap_year.rb 2000
2000年はうるう年です
$ ruby 04_leap_year.rb 2003
2003年はうるう年ではありません
```
## その他
なし